### PR TITLE
fix exclude redirect for new domains

### DIFF
--- a/src/main/java/com/novibe/dns/next_dns/service/NextDnsRewriteService.java
+++ b/src/main/java/com/novibe/dns/next_dns/service/NextDnsRewriteService.java
@@ -51,6 +51,8 @@ public class NextDnsRewriteService {
                 newRewriteRequests.remove(domain);
             }
         }
+        newRewriteRequests.keySet().removeIf(excludeRedirectCheckService::shouldExclude);
+
         if (!outdatedIds.isEmpty()) {
             Log.io("Removing %s outdated rewrites from NextDNS".formatted(outdatedIds.size()));
             NextDnsRateLimitedApiProcessor.callApi(outdatedIds, nextDnsRewriteClient::deleteRewriteById);


### PR DESCRIPTION
Исправление для exclude redirect

Исключения работали только если домен уже добавлен NextDNS
При следующем прогоне джобы, rewrite снова попадал в NextDNS

Получается, что rewrite, то удалялся, то добавлялся